### PR TITLE
Fix auto-start bug in timer

### DIFF
--- a/script.js
+++ b/script.js
@@ -87,6 +87,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 
                 if (timeLeft <= 0) {
                     clearInterval(timerInterval);
+                    timerInterval = null; // Reset interval reference
+                    isRunning = false; // Allow next timer to start
                     alarmSound.play();
                     sendNotification();
                     


### PR DESCRIPTION
## Summary
- ensure timer can restart automatically by resetting `timerInterval` and `isRunning`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68443a6d62cc8330825cddc843efd9c7